### PR TITLE
Add missing regexp import

### DIFF
--- a/mmuser.go
+++ b/mmuser.go
@@ -2,6 +2,7 @@ package irckit
 
 import (
 	"net"
+	"regexp"
 	"strings"
 	"time"
 


### PR DESCRIPTION
Found this, because the missing import causes the build of [matterircd](https://github.com/42wim/matterircd) to fail.