### PR TITLE
Allow users to skip TLS Certificate chain verification.

### DIFF
--- a/mmuser.go
+++ b/mmuser.go
@@ -32,6 +32,7 @@ type MmCfg struct {
 	DefaultServer  string
 	DefaultTeam    string
 	Insecure       bool
+	SkipTLSVerify  bool
 }
 
 func NewUserMM(c net.Conn, srv Server, cfg *MmCfg) *User {
@@ -52,6 +53,9 @@ func (u *User) loginToMattermost() (*matterclient.MMClient, error) {
 	mc := matterclient.New(u.Credentials.Login, u.Credentials.Pass, u.Credentials.Team, u.Credentials.Server)
 	if u.Cfg.Insecure {
 		mc.Credentials.NoTLS = true
+	}
+	if !u.Cfg.SkipTLSVerify {
+		mc.Credentials.SkipTLSVerify = true
 	}
 	mc.SetLogLevel(LogLevel)
 	logger.Infof("login as %s (team: %s) on %s", u.Credentials.Login, u.Credentials.Team, u.Credentials.Server)

--- a/mmuser.go
+++ b/mmuser.go
@@ -54,9 +54,8 @@ func (u *User) loginToMattermost() (*matterclient.MMClient, error) {
 	if u.Cfg.Insecure {
 		mc.Credentials.NoTLS = true
 	}
-	if !u.Cfg.SkipTLSVerify {
-		mc.Credentials.SkipTLSVerify = true
-	}
+	mc.Credentials.SkipTLSVerify = u.Cfg.SkipTLSVerify
+
 	mc.SetLogLevel(LogLevel)
 	logger.Infof("login as %s (team: %s) on %s", u.Credentials.Login, u.Credentials.Team, u.Credentials.Server)
 	err := mc.Login()


### PR DESCRIPTION
This is the associated PR for mm-go-irckit for the PR on matterircd.  https://github.com/42wim/matterircd/pull/118 

We run an internal CA, and our mattermost instance uses a certificate issued by that CA. To connect matterircd to mattermost, we needed to allow it to skip TLS Certificate verification.