### PR TITLE
Replace IRC parsing function with shellwords like function to allow for passwords with spaces.

### DIFF
--- a/mmservice_test.go
+++ b/mmservice_test.go
@@ -1,0 +1,106 @@
+package irckit
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type ParseTest struct {
+	Desc    string
+	Value   string
+	Results []string
+	IsGood  bool
+}
+
+var loginTests = []ParseTest{
+	{
+		Desc:    "base simple case",
+		Value:   "login user password",
+		Results: []string{"login", "user", "password"},
+		IsGood:  true,
+	},
+	{
+		Desc:    "Simple with server",
+		Value:   "login server user password",
+		Results: []string{"login", "server", "user", "password"},
+		IsGood:  true,
+	},
+	{
+		Desc:    "Simple with server and team",
+		Value:   "login server team user password",
+		Results: []string{"login", "server", "team", "user", "password"},
+		IsGood:  true,
+	},
+	{
+		Desc:    "Simple Long Password Login Single Quote",
+		Value:   "login user 'long password'",
+		Results: []string{"login", "user", "long password"},
+		IsGood:  true,
+	},
+	{
+		Desc:    "Long Password Login (server) Single Quote",
+		Value:   "login server user 'long password'",
+		Results: []string{"login", "server", "user", "long password"},
+		IsGood:  true,
+	},
+	{
+		Desc:    "Long Password Login (server & team) Single Quote",
+		Value:   "login server team user 'long password'",
+		Results: []string{"login", "server", "team", "user", "long password"},
+		IsGood:  true,
+	},
+	{
+		Desc:    "Simple Long Password Login Double Quote",
+		Value:   "login user \"long password\"",
+		Results: []string{"login", "user", "long password"},
+		IsGood:  true,
+	},
+	{
+		Desc:    "Long Password Login (server) Double Quote",
+		Value:   "login server user \"long password\"",
+		Results: []string{"login", "server", "user", "long password"},
+		IsGood:  true,
+	},
+	{
+		Desc:    "Long Password Login (server & team) Double Quote",
+		Value:   "login server team user \"long password\"",
+		Results: []string{"login", "server", "team", "user", "long password"},
+		IsGood:  true,
+	},
+	{
+		Desc:    "Test Last Space",
+		Value:   "login user \"long password\" ",
+		Results: []string{"login", "user", "long password"},
+		IsGood:  true,
+	},
+	{
+		Desc:    "Test Escape",
+		Value:   "login user \"\\&long password\"",
+		Results: []string{"login", "user", "&long password"},
+		IsGood:  true,
+	},
+	{
+		Desc:    "Test Escape Quote",
+		Value:   "login user \"\\\"long password\"",
+		Results: []string{"login", "user", "\"long password"},
+		IsGood:  true,
+	},
+}
+
+func TestParseCommandString(t *testing.T) {
+	fmt.Println("--------------------")
+
+	for _, tc := range loginTests {
+		results, err := parseCommandString(tc.Value)
+		if err != nil && tc.IsGood {
+			t.Fatal(tc.Desc + " should be an error.")
+		}
+		fmt.Println(tc.Desc)
+		for i, r := range tc.Results {
+			fmt.Printf("Testing [%s] == [%s]\n", results[i], r)
+			assert.Equal(t, results[i], r)
+		}
+	}
+}

--- a/mmuser.go
+++ b/mmuser.go
@@ -32,6 +32,7 @@ type MmCfg struct {
 	DefaultServer  string
 	DefaultTeam    string
 	Insecure       bool
+	SkipTLSVerify  bool
 }
 
 func NewUserMM(c net.Conn, srv Server, cfg *MmCfg) *User {
@@ -52,6 +53,9 @@ func (u *User) loginToMattermost() (*matterclient.MMClient, error) {
 	mc := matterclient.New(u.Credentials.Login, u.Credentials.Pass, u.Credentials.Team, u.Credentials.Server)
 	if u.Cfg.Insecure {
 		mc.Credentials.NoTLS = true
+	}
+	if !u.Cfg.SkipTLSVerify {
+		mc.Credentials.SkipTLSVerify = true
 	}
 	mc.SetLogLevel(LogLevel)
 	logger.Infof("login as %s (team: %s) on %s", u.Credentials.Login, u.Credentials.Team, u.Credentials.Server)

--- a/mmuser.go
+++ b/mmuser.go
@@ -54,9 +54,8 @@ func (u *User) loginToMattermost() (*matterclient.MMClient, error) {
 	if u.Cfg.Insecure {
 		mc.Credentials.NoTLS = true
 	}
-	if !u.Cfg.SkipTLSVerify {
-		mc.Credentials.SkipTLSVerify = true
-	}
+	mc.Credentials.SkipTLSVerify = u.Cfg.SkipTLSVerify
+
 	mc.SetLogLevel(LogLevel)
 	logger.Infof("login as %s (team: %s) on %s", u.Credentials.Login, u.Credentials.Team, u.Credentials.Server)
 	err := mc.Login()


### PR DESCRIPTION
Replaced the string.Fields(msg) call with a function that parses the string, allowing for quoted arguments, as well as escaped characters.

Basic unit tests are in place.

