### PR TITLE
Don't forget to strip trailing \x01

### DIFF
--- a/server_commands.go
+++ b/server_commands.go
@@ -337,6 +337,7 @@ func CmdPrivMsg(s Server, u *User, msg *irc.Message) error {
 		// CTCP ACTION (/me)
 		if strings.HasPrefix(msg.Trailing, "\x01ACTION ") {
 			msg.Trailing = strings.Replace(msg.Trailing, "\x01ACTION ", "", -1)
+			msg.Trailing = strings.Replace(msg.Trailing, "\x01", "", -1)
 			msg.Trailing = "*" + msg.Trailing + "*"
 		}
 		if ch.Service() == "slack" {


### PR DESCRIPTION
The IRC protocol describes /me as

 ... \x01ACTION writes some specs!\x01

The MM > IRC conversion already handles both delimiters, while the IRC >
MM was missing the trailing one. Thus causing visual artefacts in the MM
web interface.

Issue: https://github.com/42wim/matterircd/issues/127
Signed-off-by: Emil Velikov <emil.velikov@collabora.com>