### PR TITLE
don't log passwords used with 'mattermost' and 'slack'

### DIFF
--- a/server_commands.go
+++ b/server_commands.go
@@ -315,6 +315,7 @@ func CmdPrivMsg(s Server, u *User, msg *irc.Message) error {
 	var err error
 	if len(msg.Params) > 1 {
 		tr := strings.Join(msg.Params[1:], " ")
+		msg.Params = []string{msg.Params[0]}
 		msg.Trailing = msg.Trailing + tr
 	}
 	// empty message
@@ -362,10 +363,12 @@ func CmdPrivMsg(s Server, u *User, msg *irc.Message) error {
 	} else if toUser, exists := s.HasUser(query); exists {
 		if query == "mattermost" {
 			go u.handleServiceBot(query, toUser, msg.Trailing)
+			msg.Trailing = "<redacted>"
 			return nil
 		}
 		if query == "slack" {
 			go u.handleServiceBot(query, toUser, msg.Trailing)
+			msg.Trailing = "<redacted>"
 			return nil
 		}
 		if toUser.MmGhostUser {

--- a/user.go
+++ b/user.go
@@ -138,17 +138,15 @@ func (user *User) Decode() (*irc.Message, error) {
 	}
 	msg, err := user.Conn.Decode()
 	if err == nil && msg != nil {
-		if msg.Command == "PRIVMSG" && msg.Params != nil && (msg.Params[0] == "slack" || msg.Params[0] == "mattermost"){
+		dmsg := fmt.Sprintf("<- %s", msg)
+		if msg.Command == "PRIVMSG" && msg.Params != nil && (msg.Params[0] == "slack" || msg.Params[0] == "mattermost") {
 			// Don't log sensitive information
 			trail := strings.Split(msg.Trailing, " ")
 			if (msg.Trailing != "" && trail[0] == "login") || (len(msg.Params) > 1 && msg.Params[1] == "login") {
-				logger.Debugf("<- PRIVMSG %s :login [redacted]", msg.Params[0])
-			} else {
-				logger.Debugf("<- %s", msg)
+				dmsg = fmt.Sprintf("<- PRIVMSG %s :login [redacted]", msg.Params[0])
 			}
-		} else {
-			logger.Debugf("<- %s", msg)
 		}
+		logger.Debug(dmsg)
 	}
 	return msg, err
 }

--- a/user.go
+++ b/user.go
@@ -1,6 +1,7 @@
 package irckit
 
 import (
+	"fmt"
 	"net"
 	"strings"
 	"sync"

--- a/user.go
+++ b/user.go
@@ -138,7 +138,17 @@ func (user *User) Decode() (*irc.Message, error) {
 	}
 	msg, err := user.Conn.Decode()
 	if err == nil && msg != nil {
-		logger.Debugf("<- %s", msg)
+		if msg.Command == "PRIVMSG" && msg.Params != nil && (msg.Params[0] == "slack" || msg.Params[0] == "mattermost"){
+			// Don't log sensitive information
+			trail := strings.Split(msg.Trailing, " ")
+			if (msg.Trailing != "" && trail[0] == "login") || (len(msg.Params) > 1 && msg.Params[1] == "login") {
+				logger.Debugf("<- PRIVMSG %s :login [redacted]", msg.Params[0])
+			} else {
+				logger.Debugf("<- %s", msg)
+			}
+		} else {
+			logger.Debugf("<- %s", msg)
+		}
 	}
 	return msg, err
 }


### PR DESCRIPTION
This change is for 42wim/matterircd#73

Since the password is logged twice (the <- line, and when a Command is executed), I also had to redact the msg.Trailing contents in server_commands.go

Additionally, this sets msg.Params to just the first param after the additional are translated into Trailing, since in RFC 2812 it is specified to be just a single param for PRIVMSG (https://tools.ietf.org/html/rfc2812 3.3.1).