### PR TITLE
Handle \r, ACTION and colour sanitization everywhere

### DIFF
--- a/server_commands.go
+++ b/server_commands.go
@@ -405,25 +405,26 @@ func CmdPrivMsg(s Server, u *User, msg *irc.Message) error {
 		return nil
 	}
 	query := msg.Params[0]
-	if ch, exists := s.HasChannel(query); exists {
-		//p := strings.Replace(query, "#", "", -1)
-		msg.Trailing = strings.Replace(msg.Trailing, "\r", "", -1)
-		// fix non-rfc clients
-		if !strings.HasPrefix(msg.Trailing, ":") {
-			if len(msg.Params) == 2 {
-				msg.Trailing = msg.Params[1]
-			}
-		}
-		// CTCP ACTION (/me)
-		if strings.HasPrefix(msg.Trailing, "\x01ACTION ") {
-			msg.Trailing = strings.Replace(msg.Trailing, "\x01ACTION ", "", -1)
-			msg.Trailing = strings.Replace(msg.Trailing, "\x01", "", -1)
-			msg.Trailing = "*" + msg.Trailing + "*"
-		}
-		// strip IRC colors
-		re := regexp.MustCompile(`[[:cntrl:]](?:\d{1,2}(?:,\d{1,2})?)?`)
-		msg.Trailing = re.ReplaceAllString(msg.Trailing, "")
 
+	//p := strings.Replace(query, "#", "", -1)
+	msg.Trailing = strings.Replace(msg.Trailing, "\r", "", -1)
+	// fix non-rfc clients
+	if !strings.HasPrefix(msg.Trailing, ":") {
+		if len(msg.Params) == 2 {
+			msg.Trailing = msg.Params[1]
+		}
+	}
+	// CTCP ACTION (/me)
+	if strings.HasPrefix(msg.Trailing, "\x01ACTION ") {
+		msg.Trailing = strings.Replace(msg.Trailing, "\x01ACTION ", "", -1)
+		msg.Trailing = strings.Replace(msg.Trailing, "\x01", "", -1)
+		msg.Trailing = "*" + msg.Trailing + "*"
+	}
+	// strip IRC colors
+	re := regexp.MustCompile(`[[:cntrl:]](?:\d{1,2}(?:,\d{1,2})?)?`)
+	msg.Trailing = re.ReplaceAllString(msg.Trailing, "")
+
+	if ch, exists := s.HasChannel(query); exists {
 		if ch.Service() == "slack" {
 			np := slack.NewPostMessageParameters()
 			np.AsUser = true


### PR DESCRIPTION
Currently \r, ACTION and IRC colours are sanitized only for channels.
Any direct messages won't get the above treatment, producing garbage.

Issue: https://github.com/42wim/matterircd/issues/185
Signed-off-by: Emil Velikov <emil.velikov@collabora.com>